### PR TITLE
add possibility to make docker-compose push

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build:
       context: ./db
       dockerfile: Dockerfile
+    image: "cr.yandex/crp3ftp1b7dveeagva5g/madr-postgres:latest"
     ports:
       - "5432:5432"
     networks:
@@ -11,6 +12,7 @@ services:
       - TZ=Europe/Moscow
   madr:
     build: .
+    image: "cr.yandex/crp3ftp1b7dveeagva5g/madr-go-app:latest"
     ports:
       - "8080:8080"
     networks:
@@ -25,6 +27,7 @@ services:
     build:
       context: ./madr_web_app
       dockerfile: Dockerfile
+    image: "cr.yandex/crp3ftp1b7dveeagva5g/madr-react:latest"
     ports:
       - "80:80"
     networks:


### PR DESCRIPTION
Если сначала сделать docker compose build, а потом docker compose push, то эти образы запушатся в репу.

Этот PR упростит процесс разработки, тк вместо того чтобы каждый раз вспоминать путь до registry можно будет выполнить две простые команды